### PR TITLE
Added 'namespace' to 'ServiceAccount'

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cleanup-operator
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole


### PR DESCRIPTION
Allows successful deployment even if the kubectl's current context is not set to 'default' namespace