### PR TITLE
Update deployment api versions

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cleanup-operator
   namespace: default
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cleanup-operator
@@ -25,7 +25,7 @@ rules:
   - delete
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cleanup-operator


### PR DESCRIPTION
`extensions/v1beta1` is removed as of kubernetes 1.16, this PR updates the deployment api version to `apps/v1` for better compatibility (requires k8s 1.9 or later)

This also updates the rbac api version from `rbac.authorization.k8s.io/v1beta1` to `rbac.authorization.k8s.io/v1` for forward compatibility as well.