### PR TITLE
make client-go log to console instead of file

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"k8s.io/klog"
 	"log"
 	"os"
 	"os/signal"
@@ -19,6 +20,12 @@ import (
 func main() {
 	// Set logging output to standard console out
 	log.SetOutput(os.Stdout)
+
+	// kubernetes client-go uses klog, which logs to file by default. Change defaults to log to stderr instead of file.
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
+	logtostderr := klogFlags.Lookup("logtostderr")
+	logtostderr.Value.Set("true")
 
 	sigs := make(chan os.Signal, 1) // Create channel to receive OS signals
 	stop := make(chan struct{})     // Create channel to receive stop signal

--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,6 @@ require (
 	k8s.io/api v0.0.0-20190905160310-fb749d2f1064
 	k8s.io/apimachinery v0.0.0-20190831074630-461753078381
 	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/klog v0.4.0
 	k8s.io/utils v0.0.0-20190829053155-3a4a5477acf8 // indirect
 )


### PR DESCRIPTION
The Kubernetes client-go package was logging to file instead of console (klog defaults), which is less than ideal.
Noticed this by "accident" when applying a stricter PSP which required the rootFs to be read-only.

```
/ $ ls -lah /tmp/
total 8
drwxrwsrwx    2 root     10000        294 May  9 18:33 .
drwxr-xr-x    1 root     root          17 May  9 18:33 ..
lrwxrwxrwx    1 10000    10000         99 May  9 18:33 kube-cleanup-operator.INFO -> kube-cleanup-operator.kube-cleanup-operator-64f6f69bdc-qw8xz.unknownuser.log.INFO.20200509-183302.1
lrwxrwxrwx    1 10000    10000        102 May  9 18:33 kube-cleanup-operator.WARNING -> kube-cleanup-operator.kube-cleanup-operator-64f6f69bdc-qw8xz.unknownuser.log.WARNING.20200509-183302.1
-rw-r--r--    1 10000    10000        364 May  9 18:33 kube-cleanup-operator.kube-cleanup-operator-64f6f69bdc-qw8xz.unknownuser.log.INFO.20200509-183302.1
-rw-r--r--    1 10000    10000        364 May  9 18:33 kube-cleanup-operator.kube-cleanup-operator-64f6f69bdc-qw8xz.unknownuser.log.WARNING.20200509-183302.1

/ $ cat /tmp/kube-cleanup-operator.INFO 
Log file created at: 2020/05/09 18:33:02
Running on machine: kube-cleanup-operator-64f6f69bdc-qw8xz
Binary: Built with gc go1.13 for linux/amd64
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
W0509 18:33:02.090551       1 client_config.go:541] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.

/ $ cat /tmp/kube-cleanup-operator.WARNING 
Log file created at: 2020/05/09 18:33:02
Running on machine: kube-cleanup-operator-64f6f69bdc-qw8xz
Binary: Built with gc go1.13 for linux/amd64
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
W0509 18:33:02.090551       1 client_config.go:541] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
```

by setting the klog flags ourselves we can steer this behaviour, getting those logs in the same stream as the app logging (and being able to mount the rootFs read-only, which for us at least was a plus, without creating an emptyDir just for this)