### PR TITLE
Fix dry-run deletePods

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -227,6 +227,7 @@ func (c *Kleaner) deleteJobs(job *batchv1.Job) {
 func (c *Kleaner) deletePods(pod *corev1.Pod) {
 	if c.dryRun {
 		log.Printf("dry-run: Pod '%s:%s' would have been deleted", pod.Namespace, pod.Name)
+		return
 	}
 	log.Printf("Deleting pod '%s:%s'", pod.Namespace, pod.Name)
 	var po metav1.DeleteOptions


### PR DESCRIPTION
Ran the controller with `--dry-run=true` and it removed all the pods according to `--delete` flags…

```console
2020/06/04 00:55:56 dry-run: Pod 'xxx:yyy-6020-l3y6qrco-22kx8' would have been deleted
2020/06/04 00:55:56 Deleting pod 'xxx:yyy-6020-l3y6qrco-22kx8'
```

```bash
$ kubectl get pod -n xxx yyy-6020-l3y6qrco-22kx8                                                                                               
Error from server (NotFound): pods "yyy-6020-l3y6qrco-22kx8" not found
```

No hard feelings, early returns are tricky 😬 