### PR TITLE
Fix deletion of failed jobs

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -301,7 +301,7 @@ func extractJobFinishTime(jobObj *batchv1.Job) time.Time {
 	}
 
 	for _, jc := range jobObj.Status.Conditions {
-		// Looking for the time when pod's condition "Failed" became "true" (equals end of execution)
+		// Looking for the time when job's condition "Failed" became "true" (equals end of execution)
 		if jc.Type == batchv1.JobFailed && jc.Status == corev1.ConditionTrue {
 			return jc.LastTransitionTime.Time
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -155,18 +155,26 @@ func (c *Kleaner) Process(obj interface{}) {
 			return
 		}
 		job := t
-		// skip the job if it hasn't completed yet or has any active pods
-		if job.Status.CompletionTime.IsZero() || job.Status.Active > 0 {
+		// skip the job if it has any active pods
+		if job.Status.Active > 0 {
 			return
 		}
-		timeSinceCompletion := time.Now().Sub(job.Status.CompletionTime.Time)
+
+		finishTime := extractJobFinishTime(job)
+
+		if finishTime.IsZero() {
+			return
+		}
+
+		timeSinceFinish := time.Now().Sub(finishTime)
+
 		if job.Status.Succeeded > 0 {
-			if c.deleteSuccessfulAfter > 0 && timeSinceCompletion > c.deleteSuccessfulAfter {
+			if c.deleteSuccessfulAfter > 0 && timeSinceFinish > c.deleteSuccessfulAfter {
 				c.deleteJobs(job)
 			}
 		}
 		if job.Status.Failed > 0 {
-			if c.deleteFailedAfter > 0 && timeSinceCompletion >= c.deleteFailedAfter {
+			if c.deleteFailedAfter > 0 && timeSinceFinish >= c.deleteFailedAfter {
 				c.deleteJobs(job)
 			}
 		}
@@ -283,5 +291,21 @@ func extractPodFinishTime(podObj *corev1.Pod) time.Time {
 			return pc.LastTransitionTime.Time
 		}
 	}
+	return time.Time{}
+}
+
+// Can return "zero" time, caller must check
+func extractJobFinishTime(jobObj *batchv1.Job) time.Time {
+	if !jobObj.Status.CompletionTime.IsZero() {
+		return jobObj.Status.CompletionTime.Time
+	}
+
+	for _, jc := range jobObj.Status.Conditions {
+		// Looking for the time when pod's condition "Failed" became "true" (equals end of execution)
+		if jc.Type == batchv1.JobFailed && jc.Status == corev1.ConditionTrue {
+			return jc.LastTransitionTime.Time
+		}
+	}
+
 	return time.Time{}
 }


### PR DESCRIPTION
Noticed that controller was not deleting failed jobs in our environment.

This PR fixes finish time lookup for failed jobs.

Few examples of failed job statuses:

```json
"status": {
    "conditions": [
        {
            "lastProbeTime": "2020-06-04T02:23:44Z",
            "lastTransitionTime": "2020-06-04T02:23:44Z",
            "message": "Job has reached the specified backoff limit",
            "reason": "BackoffLimitExceeded",
            "status": "True",
            "type": "Failed"
        }
    ],
    "failed": 1,
    "startTime": "2020-06-04T02:22:30Z"
}
```

```
"status": {
        "conditions": [
            {
                "lastProbeTime": "2020-06-03T03:51:11Z",
                "lastTransitionTime": "2020-06-03T03:51:11Z",
                "message": "Job was active longer than specified deadline",
                "reason": "DeadlineExceeded",
                "status": "True",
                "type": "Failed"
            }
        ],
        "startTime": "2020-06-03T03:49:44Z"
    }
```

Confirmed that it deleted all failed jobs in our cluster after this patch.