### PR TITLE
Add build stage to the Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+bin/
+.idea/
+# Test binary, build with `go test -c`
+*.test
+*.iml
+*.md
+/.travis.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,14 @@
+FROM golang:1.14.4-alpine3.12 AS build
+
+RUN apk update && \
+    apk add build-base git
+
+COPY . /build
+WORKDIR /build
+
+RUN make install_deps
+RUN make build
+
 FROM alpine
 MAINTAINER Sergey Nuzhdin <ipaq.lw@gmail.com>
 
@@ -5,6 +16,6 @@ RUN addgroup -S kube-operator && adduser -S -g kube-operator kube-operator
 
 USER kube-operator
 
-COPY kube-cleanup-operator .
+COPY --from=build /build/bin/kube-cleanup-operator .
 
 ENTRYPOINT ["./kube-cleanup-operator"]

--- a/README.md
+++ b/README.md
@@ -38,16 +38,14 @@ kubectl create -f https://k8s.io/examples/controllers/job.yaml
 ```docker pull quay.io/lwolf/kube-cleanup-operator```
 
 or you can build it yourself as follows:
-```
-$ make install_deps
-$ make build
-$ cp bin/kube-cleanup-operator .
+
+```console
 $ docker build .
 ```
 
 ## Development
 
-```
+```console
 $ make install_deps
 $ make build
 $ ./bin/kube-cleanup-operator -run-outside-cluster -dry-run=true


### PR DESCRIPTION
This allows proper development and Docker build on macOS or Windows as well as version-controlled development environment, Go binaries are target platform specific.

I didn't update Travis release pipeline, personally I'd use this multi-stage Docker build as a Travis build but it's up to you 🙃

Docs: https://docs.docker.com/develop/develop-images/multistage-build/