### PR TITLE
Fix Typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ Pre v0.7.0
     $ ./bin/kube-cleanup-operator --help
     Usage of ./bin/kube-cleanup-operator:
       -namespace string
-            Watch only this namespaces (omit to operate clusterwide)
+            Watch only this namespace (omit to operate clusterwide)
       -run-outside-cluster
             Set this flag when running outside of the cluster.
       -keep-successful
-            the number of hours to keep a succesfull job
+            the number of hours to keep a successful job
             -1 - forever 
             0  - never (default)
             >0 - number of hours
@@ -98,7 +98,7 @@ Usage of ./bin/kube-cleanup-operator:
   -dry-run
         Print only, do not delete anything.
   -keep-failures int
-        Number of hours to keep faild jobs, -1 - forever (default) 0 - never, >0 number of hours (default -1)
+        Number of hours to keep failed jobs, -1 - forever (default) 0 - never, >0 number of hours (default -1)
   -keep-pending int
         Number of hours to keep pending jobs, -1 - forever (default) >0 number of hours (default -1)
   -keep-successful int
@@ -108,7 +108,7 @@ Usage of ./bin/kube-cleanup-operator:
   -listen-addr string
         Address to expose metrics. (default "0.0.0.0:7000")
   -namespace string
-        Limit scope to a single namespaces
+        Limit scope to a single namespace
   -run-outside-cluster
         Set this flag when running outside of the cluster.
 ```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,7 +37,7 @@ func setupLogging() {
 
 func main() {
 	runOutsideCluster := flag.Bool("run-outside-cluster", false, "Set this flag when running outside of the cluster.")
-	namespace := flag.String("namespace", "", "Limit scope to a single namespaces")
+	namespace := flag.String("namespace", "", "Limit scope to a single namespace")
 	listenAddr := flag.String("listen-addr", "0.0.0.0:7000", "Address to expose metrics.")
 
 	deleteSuccessAfter := flag.Duration("delete-successful-after", 15*time.Minute, "Delete jobs and pods in successful state after X duration (golang duration format, e.g 5m), 0 - never delete")
@@ -47,7 +47,7 @@ func main() {
 	deletePendingAfter := flag.Duration("delete-pending-pods-after", 0, "Delete pods in pending state after X duration (golang duration format, e.g 5m), 0 - never delete")
 
 	legacyKeepSuccessHours := flag.Int64("keep-successful", 0, "Number of hours to keep successful jobs, -1 - forever, 0 - never (default), >0 number of hours")
-	legacyKeepFailedHours := flag.Int64("keep-failures", -1, "Number of hours to keep faild jobs, -1 - forever (default) 0 - never, >0 number of hours")
+	legacyKeepFailedHours := flag.Int64("keep-failures", -1, "Number of hours to keep failed jobs, -1 - forever (default) 0 - never, >0 number of hours")
 	legacyKeepPendingHours := flag.Int64("keep-pending", -1, "Number of hours to keep pending jobs, -1 - forever (default) >0 number of hours")
 	legacyMode := flag.Bool("legacy-mode", true, "Legacy mode: `true` - use old `keep-*` flags, `false` - enable new `delete-*-after` flags")
 


### PR DESCRIPTION
~~A recent PR #50 changed the behavior where cronjob jobs and pods will not be deleted, which altered the previous default
However, there may be use-cases to act on them too before cronjob actually clears them on their own.
Adding an option which can be set to delete the cronjob related stuff too, which was the default way beforehand.~~

Some typos fixed.

