### PR TITLE
Add Label Selector to available parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Usage of ./bin/kube-cleanup-operator:
         Limit scope to a single namespace
   -run-outside-cluster
         Set this flag when running outside of the cluster.
+  -label-selector
+        Delete only jobs and pods that meet label selector requirements. #See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ```
 
 ### Optional parameters 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -58,6 +58,9 @@ func main() {
 	legacyMode := flag.Bool("legacy-mode", true, "Legacy mode: `true` - use old `keep-*` flags, `false` - enable new `delete-*-after` flags")
 
 	dryRun := flag.Bool("dry-run", false, "Print only, do not delete anything.")
+	
+	labelSelector := flag.String("label-selector", "", "Delete only jobs and pods that meet label selector requirements")
+	
 	flag.Parse()
 	setupLogging()
 
@@ -77,6 +80,8 @@ func main() {
 	optsInfo.WriteString(fmt.Sprintf("\tkeep-successful: %d\n", *legacyKeepSuccessHours))
 	optsInfo.WriteString(fmt.Sprintf("\tkeep-failures: %d\n", *legacyKeepFailedHours))
 	optsInfo.WriteString(fmt.Sprintf("\tkeep-pending: %d\n", *legacyKeepPendingHours))
+	
+	optsInfo.WriteString(fmt.Sprintf("\tlabel-selector: %s\n", *labelSelector))
 	log.Println(optsInfo.String())
 
 	if *legacyMode {
@@ -129,6 +134,7 @@ func main() {
 				*deleteOrphanedAfter,
 				*deleteEvictedAfter,
 				*ignoreOwnedByCronjob,
+				*labelSelector,
 				stopCh,
 			).Run()
 		}


### PR DESCRIPTION
It can be useful to manage jobs/pods in the same namespace by different rules. It is easy to achieve by running several  kube-cleanup-operator instances with different label selectors. This PR supports such ability.   
I didn't add any tests because it is functionality of underlying library, but have tested manually with empty value and something like `--label-selector=component=worker,housekeeping=true`