### PR TITLE
Fix args data type in chart values.yaml

### DIFF
--- a/deploy/helm/kube-cleanup-operator/values.yaml
+++ b/deploy/helm/kube-cleanup-operator/values.yaml
@@ -91,7 +91,7 @@ rbac:
 
 ## Arguments for kube-cleanup-operator
 ##
-args: []
+args:
   # - --namespace=default
   # - --delete-successful-after=5m
   # - --delete-failed-after=120m


### PR DESCRIPTION
Following error ```Error: failed to parse ./kube-cleanup-operator/values.yaml: error converting YAML to JSON: yaml: line 94: did not find expected key```