### PR TITLE
Add imagePullSecrets in the deployment of kube-cleanup-operator

### DIFF
--- a/deploy/helm/kube-cleanup-operator/templates/deployment.yaml
+++ b/deploy/helm/kube-cleanup-operator/templates/deployment.yaml
@@ -36,10 +36,10 @@ spec:
       annotations: {{ toYaml . | nindent 8 -}}
       {{- end }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+    {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}

--- a/deploy/helm/kube-cleanup-operator/templates/deployment.yaml
+++ b/deploy/helm/kube-cleanup-operator/templates/deployment.yaml
@@ -36,6 +36,10 @@ spec:
       annotations: {{ toYaml . | nindent 8 -}}
       {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}

--- a/deploy/helm/kube-cleanup-operator/values.yaml
+++ b/deploy/helm/kube-cleanup-operator/values.yaml
@@ -1,6 +1,9 @@
 ---
 replicas: 1
 
+# imagePullSecrets -- Kubernetes image Pull Secrets
+imagePullSecrets: []
+
 image:
   repository: quay.io/lwolf/kube-cleanup-operator
   pullPolicy: IfNotPresent


### PR DESCRIPTION
To be able to specify the secret that contains the credentials of docker registry to pull images.