### PR TITLE
Implement -some-kind switch which allows to customize ownerReference.Kind matching

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -58,9 +58,11 @@ func main() {
 	legacyMode := flag.Bool("legacy-mode", true, "Legacy mode: `true` - use old `keep-*` flags, `false` - enable new `delete-*-after` flags")
 
 	dryRun := flag.Bool("dry-run", false, "Print only, do not delete anything.")
-	
+
 	labelSelector := flag.String("label-selector", "", "Delete only jobs and pods that meet label selector requirements")
 	
+	someKind := flag.String("some-kind", "", "Specify additional ownerReferences.Kind")
+
 	flag.Parse()
 	setupLogging()
 
@@ -82,6 +84,7 @@ func main() {
 	optsInfo.WriteString(fmt.Sprintf("\tkeep-pending: %d\n", *legacyKeepPendingHours))
 	
 	optsInfo.WriteString(fmt.Sprintf("\tlabel-selector: %s\n", *labelSelector))
+	optsInfo.WriteString(fmt.Sprintf("\tsome-kind: %s\n", *someKind))
 	log.Println(optsInfo.String())
 
 	if *legacyMode {
@@ -135,6 +138,7 @@ func main() {
 				*deleteEvictedAfter,
 				*ignoreOwnedByCronjob,
 				*labelSelector,
+				*someKind,
 				stopCh,
 			).Run()
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -54,6 +54,8 @@ type Kleaner struct {
 	
 	labelSelector        string
 
+	someKind             string
+
 	dryRun bool
 	ctx    context.Context
 	stopCh <-chan struct{}
@@ -62,7 +64,7 @@ type Kleaner struct {
 // NewKleaner creates a new NewKleaner
 func NewKleaner(ctx context.Context, kclient *kubernetes.Clientset, namespace string, dryRun bool, deleteSuccessfulAfter,
 	deleteFailedAfter, deletePendingAfter, deleteOrphanedAfter, deleteEvictedAfter time.Duration, ignoreOwnedByCronjob bool,
-	labelSelector string,
+	labelSelector string, someKind string,
 	stopCh <-chan struct{}) *Kleaner {
 	jobInformer := cache.NewSharedIndexInformer(
 		&cache.ListWatch{
@@ -107,6 +109,7 @@ func NewKleaner(ctx context.Context, kclient *kubernetes.Clientset, namespace st
 		deleteEvictedAfter:    deleteEvictedAfter,
 		ignoreOwnedByCronjob:  ignoreOwnedByCronjob,
 		labelSelector:         labelSelector,
+		someKind:              someKind,
 	}
 	jobInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(old, new interface{}) {
@@ -180,7 +183,7 @@ func (c *Kleaner) Process(obj interface{}) {
 			return
 		}
 		// normal cleanup flow
-		if shouldDeletePod(t, c.deleteOrphanedAfter, c.deletePendingAfter, c.deleteEvictedAfter, c.deleteSuccessfulAfter, c.deleteFailedAfter) {
+		if shouldDeletePod(t, c.someKind, c.deleteOrphanedAfter, c.deletePendingAfter, c.deleteEvictedAfter, c.deleteSuccessfulAfter, c.deleteFailedAfter) {
 			c.DeletePod(t)
 		}
 	}


### PR DESCRIPTION
I use this one to clean-up Kubeflow Pipeline jobs scheduled on EKS/Fargate - some adjustments are probably needed, tests, etc - for now I'm leaving it here to watch if anyone is interested in using that.