### PR TITLE
Support helm template in values yaml

### DIFF
--- a/deploy/helm/kube-cleanup-operator/Chart.yaml
+++ b/deploy/helm/kube-cleanup-operator/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: kube-cleanup-operator
 description: Kubernetes Operator to automatically delete completed Jobs and their Pods
 type: application
-version: 1.0.4
+version: 1.0.5
 appVersion: v0.8.2
 keywords:
 - kubernetes

--- a/deploy/helm/kube-cleanup-operator/templates/deployment.yaml
+++ b/deploy/helm/kube-cleanup-operator/templates/deployment.yaml
@@ -9,9 +9,9 @@ metadata:
     helm.sh/chart: {{ include "app.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{ with .Values.labels }}{{ toYaml . | indent 4 }}{{ end }}
+{{ with .Values.labels }}{{ tpl ( toYaml . ) $ | indent 4 }}{{ end }}
   {{- with .Values.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  annotations: {{ tpl ( toYaml . ) $ | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.replicas }}
@@ -31,53 +31,53 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         helm.sh/from: deploy.{{ include "app.fullname" . }}
-{{ with .Values.podLabels }}{{ toYaml . | indent 8 }}{{ end }}
+{{ with .Values.podLabels }}{{ tpl ( toYaml . ) $ | indent 8 }}{{ end }}
       {{- with .Values.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 -}}
+      annotations: {{ tpl ( toYaml . ) $ | nindent 8 -}}
       {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl ( toYaml . ) $ | nindent 8 }}
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.args }}
-          args: {{ toYaml . | nindent 12 }}
+          args: {{ tpl ( toYaml . ) $  | nindent 12 }}
           {{- end }}
           {{- with .Values.envVariables }}
-          env: {{ toYaml . | nindent 12 }}
+          env: {{ tpl ( toYaml . ) $ | nindent 12 }}
           {{- end }}
           ports:
             - name: metrics
               containerPort: 7000
               protocol: TCP
           {{- with .Values.livenessProbe }}
-          livenessProbe: {{ toYaml . | nindent 12 }}
+          livenessProbe: {{ tpl ( toYaml . ) $ | nindent 12 }}
           {{- end }}
           {{- with .Values.readinessProbe }}
-          readinessProbe: {{ toYaml . | nindent 12 }}
+          readinessProbe: {{ tpl ( toYaml . ) $ | nindent 12 }}
           {{- end }}
           {{- with .Values.resources }}
-          resources: {{ toYaml . | nindent 12 }}
+          resources: {{ tpl ( toYaml . ) $ | nindent 12 }}
           {{- end }}
           {{- with .Values.containerSecurityContext }}
-          securityContext: {{ toYaml . | nindent 12 }}
+          securityContext: {{ tpl ( toYaml . ) $ | nindent 12 }}
           {{- end }}
       {{- with .Values.nodeSelector }}
-      nodeSelector: {{ toYaml . | nindent 8 }}
+      nodeSelector: {{ tpl ( toYaml . ) $ | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "app.fullname" . }}
       {{- with .Values.affinity }}
-      affinity: {{ toYaml . | nindent 8 }}
+      affinity: {{ tpl ( toYaml . ) $ | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
-      tolerations: {{ toYaml . | nindent 8 }}
+      tolerations: {{ tpl ( toYaml . ) $ | nindent 8 }}
       {{- end }}
       {{- with .Values.securityContext }}
-      securityContext: {{ toYaml . | nindent 8 }}
+      securityContext: {{ tpl ( toYaml . ) $ | nindent 8 }}
       {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/deploy/helm/kube-cleanup-operator/templates/service.yaml
+++ b/deploy/helm/kube-cleanup-operator/templates/service.yaml
@@ -9,9 +9,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/from: deploy.{{ include "app.fullname" . }}
-    {{- with .Values.service.labels }}{{ toYaml . | nindent 4 }}{{ end }}
+    {{- with .Values.service.labels }}{{ tpl ( toYaml . ) $ | nindent 4 }}{{ end }}
   {{- with .Values.service.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  annotations: {{ tpl ( toYaml . ) $ | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/deploy/helm/kube-cleanup-operator/templates/servicemonitor.yaml
+++ b/deploy/helm/kube-cleanup-operator/templates/servicemonitor.yaml
@@ -9,9 +9,9 @@ metadata:
     helm.sh/chart: {{ include "app.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{ with .Values.serviceMonitor.labels }}{{ toYaml . | indent 4 }}{{ end }}
+{{ with .Values.serviceMonitor.labels }}{{ tpl ( toYaml . ) $ | indent 4 }}{{ end }}
   {{- with .Values.serviceMonitor.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  annotations: {{ tpl ( toYaml . ) $ | nindent 4 }}
   {{- end }}
 spec:
   selector:
@@ -22,7 +22,7 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/managed-by: {{ .Release.Service }}
       helm.sh/from: deploy.{{ include "app.fullname" . }}
-      {{- with .Values.service.labels }}{{ toYaml . | nindent 6 }}{{ end }}
+      {{- with .Values.service.labels }}{{ tpl ( toYaml . ) $ | nindent 6 }}{{ end }}
   endpoints:
     - port: metrics
       interval: {{ .Values.serviceMonitor.scrapeInterval }}

--- a/deploy/helm/kube-cleanup-operator/values.yaml
+++ b/deploy/helm/kube-cleanup-operator/values.yaml
@@ -106,7 +106,7 @@ rbac:
 ## Arguments for kube-cleanup-operator
 ##
 args: []
-  # - --namespace=default
+  # - --namespace={{ .Release.Namespace }}
   # - --delete-successful-after=5m
   # - --delete-failed-after=120m
   # - --delete-pending-pods-after=60m


### PR DESCRIPTION
Allow to use helm template in `values.yaml` to allow some values to be auto generated during deployment time.

My main purpose is for `args` section, but adding [`tpl`](https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function) to various other places in case needed. 

For example, without template support, a different override is needed for each namespace cleanup-operator was deployed. With template support, we can simply use below template so that namespace can be set automatically when deploying.

```
args:
  - --namespace={{ .Release.Namespace }}
```