### PR TITLE
Multi-arch images with Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Test
+        run: make test
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: "~> v1"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  Test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Test
+        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.dylib
 bin/
 .idea/
+dist/
 # Test binary, build with `go test -c`
 *.test
 *.iml

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,22 +3,16 @@
 project_name: kube-cleanup-operator
 
 builds:
-  - binary: kube-cleanup-operator
+  - id: build
+    binary: kube-cleanup-operator
     main: ./cmd/main.go
     env:
     - CGO_ENABLED=0
     goos:
-      - darwin
       - linux
     goarch:
       - amd64
       - arm64
-      - arm7
-    ignore:
-      - goos: darwin
-        goarch: arm7
-      - goos: darwin
-        goarch: arm64
 
 release:
   github:
@@ -27,11 +21,41 @@ release:
   prerelease: true
 
 dockers:
-  - dockerfile: Dockerfile.releaser
-    binaries:
-      - kube-cleanup-operator
+  - id: release-amd64
+    dockerfile: Dockerfile.releaser
+    use: buildx
     goos: linux
     goarch: amd64
+    ids:
+      - build
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/amd64"
     image_templates:
-    - 'quay.io/lwolf/kube-cleanup-operator:{{ .Tag }}'
-    - 'quay.io/lwolf/kube-cleanup-operator:latest'
+      - "quay.io/lwolf/kube-cleanup-operator:{{ .Version }}-amd64"
+
+  - id: release-arm64
+    dockerfile: Dockerfile.releaser
+    use: buildx
+    goos: linux
+    goarch: arm64
+    ids:
+      - build
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+    image_templates:
+      - "quay.io/lwolf/kube-cleanup-operator:{{ .Version }}-arm64"
+
+docker_manifests:
+  - id: manifest-release
+    name_template: "quay.io/lwolf/kube-cleanup-operator:{{ .Version }}"
+    image_templates:
+      - "quay.io/lwolf/kube-cleanup-operator:{{ .Version }}-amd64"
+      - "quay.io/lwolf/kube-cleanup-operator:{{ .Version }}-arm64"
+
+  - id: manifest-latest
+    name_template: "quay.io/lwolf/kube-cleanup-operator:latest"
+    image_templates:
+      - "quay.io/lwolf/kube-cleanup-operator:{{ .Version }}-amd64"
+      - "quay.io/lwolf/kube-cleanup-operator:{{ .Version }}-arm64"


### PR DESCRIPTION
Hi @lwolf,

I've created two Github actions that should do the job of replacing Travis:

- `test.yml` : runs on pull request creation and simply runs `make test` at this stage
- `release.yml` : runs on tag creation, and uses GoReleaser to build and push multi-arch images and manifests

Caveat - this is my first time using GoReleaser. I tested this using my dockerhub login and it seems to work okay: https://hub.docker.com/r/awilmore/kube-cleanup-operator/tags

The github action requires that you set the values for `QUAY_USERNAME` and `QUAY_PASSWORD` as action secrets here: https://github.com/lwolf/kube-cleanup-operator/settings/secrets/actions

That's about it. I hope this is enough info to get this set up as your Travis replacement.

**UPDATE**

This PR addresses:
- https://github.com/lwolf/kube-cleanup-operator/issues/65
- https://github.com/lwolf/kube-cleanup-operator/issues/21
